### PR TITLE
feat: add agent-browser mount point

### DIFF
--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -90,7 +90,10 @@ $PROJECT_DIR            # Project directory (mounted at full host path)
 /home/agent/.config/opencode  # OpenCode config
 /home/agent/.local/share/opencode  # OpenCode auth
 /home/agent/.local/share/pnpm  # pnpm global store
+/home/agent/.agent-browser  # Agent-browser data (sessions, config)
 ```
+
+**Agent-Browser Support**: The mount point for `~/.agent-browser/` persists session state across container restarts. agent-browser itself is not baked into the image — it is installed at runtime via the `docker-agent-browser` skill from [github.com/shrwnsan/agents](https://github.com/shrwnsan/agents). This avoids ~300-400MB image bloat and works with any tool (Claude, OpenCode, Pi).
 
 ## Testing Status
 - Basic functionality verified (help command, shell mode)

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ Both tools use bind mounts to share authentication across all AgentBox projects:
 **Pi**:
 - `~/.pi` mounted at `/home/agent/.pi`
 
+### Agent-Browser
+
+`~/.agent-browser` is mounted at `/home/agent/.agent-browser` for session persistence. To use agent-browser in containers, install the [docker-agent-browser skill](https://github.com/shrwnsan/agents) — it handles npm install and system Chromium setup (including the Linux ARM64 workaround).
+
 ## Advanced Usage
 
 ### Running One-Off Commands

--- a/agentbox
+++ b/agentbox
@@ -373,6 +373,13 @@ run_container() {
         log_info "Agents directory mounted"
     fi
 
+    # Mount agent-browser data (sessions, config)
+    local agent_browser_dir="${HOME}/.agent-browser"
+    if [[ -d "$agent_browser_dir" ]]; then
+        mount_opts+=(-v "${agent_browser_dir}:/home/agent/.agent-browser")
+        log_info "Agent-browser data mounted"
+    fi
+
     # Set tool environment variable
     mount_opts+=(--env "TOOL=$tool")
 


### PR DESCRIPTION
## Summary
- Mount `~/.agent-browser/` into container for session persistence
- Document agent-browser setup in README and DEVELOPMENT_NOTES
- agent-browser is installed at runtime via the [docker-agent-browser skill](https://github.com/shrwnsan/agents) — no image bloat

## Test plan
- [ ] Run AgentBox with `~/.agent-browser/` present on host — verify mount log message
- [x] Run AgentBox without `~/.agent-browser/` — verify graceful skip
- [ ] Invoke docker-agent-browser skill in container — verify end-to-end setup

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5