### PR TITLE
feat: add optional toolchain toggles with .env support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ARG AGENTBOX_INCLUDE_JAVA=true
 # Include OpenCode (default: on)
 ARG AGENTBOX_INCLUDE_OPENCODE=true
 
+# Include GitLab CLI (default: on)
+ARG AGENTBOX_INCLUDE_GITLAB=true
+
 # Prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
@@ -63,15 +66,17 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install GitLab CLI
-RUN ARCH=$(dpkg --print-architecture) && \
-    GLAB_VERSION=$(curl -sL "https://gitlab.com/api/v4/projects/34675721/releases/permalink/latest" | sed -n 's/.*"tag_name":"v\?\([^"]*\)".*/\1/p') && \
-    echo "Installing glab version ${GLAB_VERSION} for ${ARCH}" && \
-    curl -fsSL -o /tmp/glab.deb \
-        "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${ARCH}.deb" && \
-    dpkg -i /tmp/glab.deb || apt-get install -f -y && \
-    rm /tmp/glab.deb && \
-    glab --version
+# Install GitLab CLI (conditional)
+RUN if [ "$AGENTBOX_INCLUDE_GITLAB" = "true" ]; then \
+        ARCH=$(dpkg --print-architecture) && \
+        GLAB_VERSION=$(curl -sL "https://gitlab.com/api/v4/projects/34675721/releases/permalink/latest" | sed -n 's/.*"tag_name":"v\?\([^"]*\)".*/\1/p') && \
+        echo "Installing glab version ${GLAB_VERSION} for ${ARCH}" && \
+        curl -fsSL -o /tmp/glab.deb \
+            "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${ARCH}.deb" && \
+        dpkg -i /tmp/glab.deb || apt-get install -f -y && \
+        rm /tmp/glab.deb && \
+        glab --version; \
+    fi
 
 # Create non-root user
 ARG USER_ID=1000

--- a/agentbox
+++ b/agentbox
@@ -84,16 +84,17 @@ get_container_name() {
 calculate_combined_hash() {
     local include_java="$1"
     local include_opencode="$2"
+    local include_gitlab="$3"
 
     local dockerfile_hash=$(calculate_hash "$DOCKERFILE_PATH")
     local entrypoint_hash=$(calculate_hash "$ENTRYPOINT_PATH")
-    local config_hash=$(echo -n "${include_java}-${include_opencode}" | sha256sum | cut -d' ' -f1)
+    local config_hash=$(echo -n "${include_java}-${include_opencode}-${include_gitlab}" | sha256sum | cut -d' ' -f1)
     echo "${dockerfile_hash}-${entrypoint_hash}-${config_hash}"
 }
 
 # Check if image needs rebuild
 needs_rebuild() {
-    local combined_hash=$(calculate_combined_hash "$include_java" "$include_opencode")
+    local combined_hash=$(calculate_combined_hash "$include_java" "$include_opencode" "$include_gitlab")
 
     # Check if image exists
     if ! $RUNTIME image inspect "$IMAGE_NAME" &> /dev/null; then
@@ -114,7 +115,7 @@ needs_rebuild() {
 
 # Build Docker image
 build_image() {
-    local combined_hash=$(calculate_combined_hash "$include_java" "$include_opencode")
+    local combined_hash=$(calculate_combined_hash "$include_java" "$include_opencode" "$include_gitlab")
 
     log_build "Building AgentBox image (this may take a few minutes on first run)..."
 
@@ -131,6 +132,7 @@ build_image() {
         --build-arg BUILD_TIMESTAMP=${build_timestamp} \
         --build-arg AGENTBOX_INCLUDE_JAVA="${include_java}" \
         --build-arg AGENTBOX_INCLUDE_OPENCODE="${include_opencode}" \
+        --build-arg AGENTBOX_INCLUDE_GITLAB="${include_gitlab}" \
         --label "agentbox.hash=${combined_hash}" \
         --label "agentbox.version=1.0.0" \
         --label "agentbox.built=${build_timestamp}" \
@@ -511,6 +513,7 @@ Options:
     --ignore-dot-env        Do not load .env files as environment variables (still mounted)
     --no-java               Exclude Java toolchain for smaller image (default: included)
     --no-opencode           Exclude OpenCode installation for smaller image (default: included)
+    --no-gitlab             Exclude GitLab CLI installation for smaller image (default: included)
 
 Commands:
     shell [--admin]         Start interactive shell instead of Claude CLI
@@ -603,6 +606,7 @@ main() {
     local tool="${AGENTBOX_TOOL:-claude}"
     local include_java="${AGENTBOX_INCLUDE_JAVA:-true}"
     local include_opencode="${AGENTBOX_INCLUDE_OPENCODE:-true}"
+    local include_gitlab="${AGENTBOX_INCLUDE_GITLAB:-true}"
     local ignore_dot_env="${AGENTBOX_IGNORE_DOT_ENV:-false}"
 
     while [[ $# -gt 0 ]]; do
@@ -652,6 +656,10 @@ main() {
                 ;;
             --no-opencode)
                 include_opencode=false
+                shift
+                ;;
+            --no-gitlab)
+                include_gitlab=false
                 shift
                 ;;
             shell)

--- a/agentbox
+++ b/agentbox
@@ -585,6 +585,14 @@ ssh_setup() {
 
 # Main execution
 main() {
+    # Source agentbox env file so build arg defaults reflect user config
+    local agentbox_env="${HOME}/.agentbox/.env"
+    if [[ -f "$agentbox_env" ]]; then
+        set -a
+        source "$agentbox_env"
+        set +a
+    fi
+
     # Parse arguments
     local force_rebuild=false
     local shell_mode=false


### PR DESCRIPTION
## Summary
- Fix `~/.agentbox/.env` not being sourced for build arg defaults (AGENTBOX_INCLUDE_* vars had no effect)
- Add `AGENTBOX_INCLUDE_GITLAB` toggle to conditionally skip GitLab CLI install

## Test plan
- [x] Verify `AGENTBOX_INCLUDE_JAVA=false` in `~/.agentbox/.env` now skips Java/SDKMAN build
- [x] Verify `AGENTBOX_INCLUDE_GITLAB=false` skips glab install
- [x] Run `agentbox --no-gitlab` and confirm glab is not installed
- [x] Run `agentbox` with both toggles true and confirm full build

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5